### PR TITLE
DRAFT Red61 fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.evopayments</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>0.0.1</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>${packaging.type}</packaging>
 
 	<properties>

--- a/src/main/java/com/evopayments/turnkey/apiclient/BaseApiCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/BaseApiCall.java
@@ -50,11 +50,6 @@ public abstract class BaseApiCall extends ApiCall {
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
-		tokenParams.put("channel", inputParams.get("channel"));
-		tokenParams.put("amount", inputParams.get("amount"));
-		tokenParams.put("currency", inputParams.get("currency"));
-		tokenParams.put("country", inputParams.get("country"));
-		tokenParams.put("paymentSolutionId", inputParams.get("paymentSolutionId"));
 		tokenParams.put("merchantNotificationUrl", config.getProperty(MERCHANT_NOTIFICATION_URL_PROP_KEY));
 
 		if(SUB_ACTION_COF_FIRST.equals(this.subActionType)){
@@ -64,6 +59,9 @@ public abstract class BaseApiCall extends ApiCall {
 			tokenParams.put("cardOnFileInitiator", "Merchant");
 			tokenParams.put("cardOnFileInitialTransactionId",inputParams.get("cardOnFileInitialTransactionId"));
 		}
+
+                tokenParams.putAll(inputParams); // Pass all inputParams to Session
+
 		return tokenParams;
 	}
 

--- a/src/main/java/com/evopayments/turnkey/apiclient/CaptureCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/CaptureCall.java
@@ -54,11 +54,11 @@ public class CaptureCall extends ApiCall {
 
 		tokenParams.put("merchantId", config.getProperty(MERCHANT_ID_PROP_KEY));
 		tokenParams.put("password", config.getProperty(PASSWORD_PROP_KEY));
-		tokenParams.put("originalMerchantTxId", inputParams.get("originalMerchantTxId"));
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
-		tokenParams.put("amount", inputParams.get("amount"));
+
+		tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/GetAvailablePaymentSolutionsCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/GetAvailablePaymentSolutionsCall.java
@@ -51,13 +51,15 @@ public class GetAvailablePaymentSolutionsCall extends ApiCall {
 	@Override
 	protected Map<String, String> getTokenParams(final Map<String, String> inputParams) {
 
-		final Map<String, String> tokenParams = new HashMap<>(inputParams); // all of the input params plus the ones below
+		final Map<String, String> tokenParams = new HashMap<>();
 
 		tokenParams.put("merchantId", config.getProperty(MERCHANT_ID_PROP_KEY));
 		tokenParams.put("password", config.getProperty(PASSWORD_PROP_KEY));
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
+
+                tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/PurchaseTokenCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/PurchaseTokenCall.java
@@ -67,6 +67,8 @@ public class PurchaseTokenCall extends ApiCall {
 		tokenParams.put("merchantNotificationUrl", config.getProperty(MERCHANT_NOTIFICATION_URL_PROP_KEY));
 		tokenParams.put("merchantLandingPageUrl", config.getProperty(MERCHANT_LANDING_PAGE_URL_PROP_KEY));
 
+		tokenParams.put("merchantTxId", inputParams.get("merchantTxId"));
+
 		return tokenParams;
 	}
 

--- a/src/main/java/com/evopayments/turnkey/apiclient/PurchaseTokenCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/PurchaseTokenCall.java
@@ -59,15 +59,10 @@ public class PurchaseTokenCall extends ApiCall {
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
-		tokenParams.put("channel", inputParams.get("channel"));
-		tokenParams.put("amount", inputParams.get("amount"));
-		tokenParams.put("currency", inputParams.get("currency"));
-		tokenParams.put("country", inputParams.get("country"));
-		tokenParams.put("paymentSolutionId", inputParams.get("paymentSolutionId"));
 		tokenParams.put("merchantNotificationUrl", config.getProperty(MERCHANT_NOTIFICATION_URL_PROP_KEY));
 		tokenParams.put("merchantLandingPageUrl", config.getProperty(MERCHANT_LANDING_PAGE_URL_PROP_KEY));
 
-		tokenParams.put("merchantTxId", inputParams.get("merchantTxId"));
+		tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/RefundCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/RefundCall.java
@@ -54,11 +54,11 @@ public class RefundCall extends ApiCall {
 
 		tokenParams.put("merchantId", config.getProperty(MERCHANT_ID_PROP_KEY));
 		tokenParams.put("password", config.getProperty(PASSWORD_PROP_KEY));
-		tokenParams.put("originalMerchantTxId", inputParams.get("originalMerchantTxId"));
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
-		tokenParams.put("amount", inputParams.get("amount"));
+
+		tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/StatusCheckCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/StatusCheckCall.java
@@ -41,6 +41,8 @@ public class StatusCheckCall extends ApiCall {
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
 
+                tokenParams.putAll(inputParams); // Pass all inputParams to Session
+
 		return tokenParams;
 	}
 

--- a/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
@@ -60,10 +60,9 @@ public class TokenizeCall extends ApiCall {
                 
                 tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
-                // Hack to work around session wanting year as 2 digits and action as 4
-                String expiryYear = tokenParams.get("expiryYear");
-                if(expiryYear.length() == 4) {
-                    tokenParams.put("expiryYear", expiryYear.substring(2,2));
+                // Remmove action params
+                for(String key : Arrays.asList("number", "nameOnCard", "expiryMonth", "expiryYear")) {
+                    tokenParams.remove(key);
                 }
 
 		return tokenParams;

--- a/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
@@ -57,6 +57,8 @@ public class TokenizeCall extends ApiCall {
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
+                
+                tokenParams.put("customerId", inputParams.get("customerId"));
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
@@ -60,6 +60,12 @@ public class TokenizeCall extends ApiCall {
                 
                 tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
+                // Hack to work around session wanting year as 2 digits and action as 4
+                String expiryYear = tokenParams.get("expiryYear");
+                if(expiryYear.length() == 4) {
+                    tokenParams.put("expiryYear", expiryYear.substring(2,2));
+                }
+
 		return tokenParams;
 	}
 

--- a/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/TokenizeCall.java
@@ -58,7 +58,7 @@ public class TokenizeCall extends ApiCall {
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
                 
-                tokenParams.put("customerId", inputParams.get("customerId"));
+                tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}

--- a/src/main/java/com/evopayments/turnkey/apiclient/VoidCall.java
+++ b/src/main/java/com/evopayments/turnkey/apiclient/VoidCall.java
@@ -58,7 +58,8 @@ public class VoidCall extends ApiCall {
 		tokenParams.put("action", getActionType().getCode());
 		tokenParams.put("timestamp", String.valueOf(System.currentTimeMillis()));
 		tokenParams.put("allowOriginUrl", config.getProperty(ALLOW_ORIGIN_URL_PROP_KEY));
-		tokenParams.put("amount", inputParams.get("amount"));
+
+		tokenParams.putAll(inputParams); // Pass all inputParams to Session
 
 		return tokenParams;
 	}


### PR DESCRIPTION
Allow all params to be passed to SessionToken request

Note: for some reason, GetAvailablePaymentSolutionsCall was already passing the params.  I have changed to add the params *after* any reading of values from the config happens to make consistent with the change to the other calls. This will mean that if you passed the wrong merchantId in the past as a param, but had right in the config it would work for that call, but would now break.

An alternative approach would be to always initalise the tokenParams based on inputParams but then that would be bigger change and prevent users from overriding the values in the config properties files at runtime 